### PR TITLE
Switch from deprecated Hoe.new to Hoe.spec

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -1,17 +1,10 @@
-.
-./generators
-./generators/full_migration_test
 ./generators/full_migration_test/full_migration_test_generator.rb
-./generators/full_migration_test/templates
 ./generators/full_migration_test/templates/full_migration_test.rb
 ./generators/full_migration_test/USAGE
-./generators/migration_test
 ./generators/migration_test/migration_test_generator.rb
-./generators/migration_test/templates
 ./generators/migration_test/templates/migration_test.rb
 ./init.rb
 ./install.rb
-./lib
 ./lib/migration_test_helper.rb
 ./LICENSE
 ./Manifest.txt

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 
 GEM_VERSION = '1.3.3'
 
-Hoe.new('migration_test_helper',GEM_VERSION) do |p|
+Hoe.spec('migration_test_helper') do |p|
   p.author = "Micah Alles" 
   p.email = "micah@atomicobject.com" 
   p.url = "http://migrationtest.rubyforge.org" 


### PR DESCRIPTION
Fixes the following deprecation warning that appears when running e.g.
"rake -T":

  Hoe.new {...} deprecated. Switch to Hoe.spec.

Directories had to be removed from Manifest.txt to avoid errors like
this after the Hoe.new -> Hoe.spec switch:

  Is a directory - ./generators/full_migration_test/templates

Closes #4.
